### PR TITLE
Fix typo in a key name

### DIFF
--- a/src/containers/PanelRightContainer.js
+++ b/src/containers/PanelRightContainer.js
@@ -5,7 +5,7 @@ import { closePanelRight, goToAboutPageFromRightPanel, goToFormPageFromRightPane
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    onClosePaneRight: () => dispatch(closePanelRight()),
+    onClosePanelRight: () => dispatch(closePanelRight()),
     onGoToAbout: () => dispatch(goToAboutPageFromRightPanel()),
     onGoToForm: () => dispatch(goToFormPageFromRightPanel()),
   };


### PR DESCRIPTION
The key that was supposed to read "onClosePanelRight" was missing a letter in its name. This resulted in the right panel not closing when backdrop is clicked. With this fix the panel correctly closes as it was intended to when the backdrop is clicked.